### PR TITLE
Fix fluffy puff loot

### DIFF
--- a/src/main/resources/data/silentgems/loot_tables/blocks/fluffy_puff_plant.json
+++ b/src/main/resources/data/silentgems/loot_tables/blocks/fluffy_puff_plant.json
@@ -5,23 +5,36 @@
       "rolls": 1,
       "entries": [
         {
-          "type": "minecraft:item",
-          "name": "silentgems:fluffy_puff",
-          "functions": [
+          "type": "minecraft:alternatives",
+          "children": [
             {
-              "function": "minecraft:set_count",
-              "count": 2
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:block_state_property",
+                  "block": "silentgems:fluffy_puff_plant",
+                  "properties": {
+                    "age": "7"
+                  }
+                }
+              ],
+              "name": "silentgems:fluffy_puff"
+            },
+            {
+              "type": "minecraft:item",
+              "name": "silentgems:fluffy_puff_seeds"
             }
           ]
         }
       ],
-      "name": "pool_added"
+    "name": "pool_added"
     },
     {
       "rolls": 1.0,
       "entries": [
         {
           "type": "minecraft:item",
+		  "name": "silentgems:fluffy_puff",
           "functions": [
             {
               "function": "minecraft:apply_bonus",
@@ -32,8 +45,8 @@
                 "probability": 0.5714286
               }
             }
-          ],
-          "name": "silentgems:fluffy_puff"
+          ]
+          
         }
       ],
       "conditions": [

--- a/src/main/resources/data/silentgems/loot_tables/blocks/wild_fluffy_puff_plant.json
+++ b/src/main/resources/data/silentgems/loot_tables/blocks/wild_fluffy_puff_plant.json
@@ -15,6 +15,27 @@
         }
       ],
       "name": "pool0"
+    },
+	{
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "silentgems:fluffy_puff"
+        }
+      ],
+      "name": "pool1",
+	  "conditions": [
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "silentgems:wild_fluffy_puff_plant",
+          "properties": {
+            "age": "7"
+          }
+        }
+      ]
     }
+	
+	
   ]
 }

--- a/src/main/resources/data/silentgems/loot_tables/blocks/wild_fluffy_puff_plant.json
+++ b/src/main/resources/data/silentgems/loot_tables/blocks/wild_fluffy_puff_plant.json
@@ -15,27 +15,6 @@
         }
       ],
       "name": "pool0"
-    },
-	{
-      "rolls": 1,
-      "entries": [
-        {
-          "type": "minecraft:item",
-          "name": "silentgems:fluffy_puff"
-        }
-      ],
-      "name": "pool1",
-	  "conditions": [
-        {
-          "condition": "minecraft:block_state_property",
-          "block": "silentgems:wild_fluffy_puff_plant",
-          "properties": {
-            "age": "7"
-          }
-        }
-      ]
     }
-	
-	
   ]
 }


### PR DESCRIPTION
Fixes #423 , Fixes #422

Wild fluffy puff only gives one, not sure if that's what you were going for with the different blocks + loottables